### PR TITLE
Added struts and struts-el dependencies

### DIFF
--- a/archetypes/liferay-theme-archetype/src/main/resources/archetype-resources/pom.xml
+++ b/archetypes/liferay-theme-archetype/src/main/resources/archetype-resources/pom.xml
@@ -86,6 +86,18 @@
 			<version>2.0</version>
 			<scope>provided</scope>
 		</dependency>
+        <dependency>
+            <groupId>struts</groupId>
+            <artifactId>struts</artifactId>
+            <version>1.2.9</version>
+            <scope>compile</scope>
+        </dependency>
+        <dependency>
+            <groupId>struts</groupId>
+            <artifactId>struts-el</artifactId>
+            <version>1.2.9</version>
+            <scope>compile</scope>
+        </dependency>
 	</dependencies>
 	<properties>
 		<liferay.theme.parent>_styled</liferay.theme.parent>


### PR DESCRIPTION
Added struts and struts-el dependencies to avoid warnings on jboss theme deloy:
java.lang.ClassNotFoundException:  org.apache.portals.bridges.struts.taglib.ELImgTag
java.lang.ClassNotFoundException:  org.apache.portals.bridges.struts.taglib.LinkTag
java.lang.ClassNotFoundException: org.apache.strutsel.taglib.html.ELImageTag
