### PR TITLE
MAVEN-104

### DIFF
--- a/plugins/liferay-maven-plugin/src/main/java/com/liferay/maven/plugins/AbstractLiferayMojo.java
+++ b/plugins/liferay-maven-plugin/src/main/java/com/liferay/maven/plugins/AbstractLiferayMojo.java
@@ -420,6 +420,10 @@ public abstract class AbstractLiferayMojo extends AbstractMojo {
 
 			toolsClassPath.add(url.toString());
 		}
+		
+		URI uri = appServerClassesPortalDir.toURI();
+		URL url = uri.toURL();
+		toolsClassPath.add(url.toString());
 
 		getLog().debug("Tools class path:");
 


### PR DESCRIPTION
${app.server.classes.portal.dir} needs to be included in classpath to allow LangBuilder initialize properly. It needs to read authorization keys from deployed portal-ext.properties file
to use Microsoft Translator service.
