### PR TITLE
6.2.10.12

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,6 @@ target
 */**/.project
 */**/.settings
 */**/target
+*/**/.idea
+plugins/liferay-maven-plugin/.idea/workspace.xml
+*.iml

--- a/plugins/liferay-maven-plugin/pom.xml
+++ b/plugins/liferay-maven-plugin/pom.xml
@@ -4,7 +4,7 @@
 	<parent>
 		<artifactId>plugins</artifactId>
 		<groupId>com.liferay.maven</groupId>
-		<version>6.2.10.11</version>
+		<version>6.2.10.12-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 	<modelVersion>4.0.0</modelVersion>

--- a/plugins/liferay-maven-plugin/src/main/java/com/liferay/maven/plugins/AbstractLiferayMojo.java
+++ b/plugins/liferay-maven-plugin/src/main/java/com/liferay/maven/plugins/AbstractLiferayMojo.java
@@ -326,12 +326,8 @@ public abstract class AbstractLiferayMojo extends AbstractMojo {
 	private static List<String> toolsClassPath = new ArrayList<String>();
 
 	protected List<String> getToolsClassPath() throws Exception {
-		if ( initialized ) {
-			getLog().info("Already initialized");
+		if ( !toolsClassPath.isEmpty() )
 			return toolsClassPath;
-		}
-		getLog().info("Not initialized yet");
-		initialized = true;
 
 		if ((appServerLibGlobalDir != null) && appServerLibGlobalDir.exists()) {
 			Collection<File> globalJarFiles = FileUtils.listFiles(
@@ -462,9 +458,9 @@ public abstract class AbstractLiferayMojo extends AbstractMojo {
 
 			addDependencyToClassPath(toolsClassPath, jspApiDependency);
 		}
-		getLog().info("Extracting additional jars...");
+
 		ExtractorUtil.getInstance().extractWeb(liferayVersion, "WEB-INF/lib/**/*.*");
-		getLog().info("Extracting complete...");
+
 		Collection<File> portalJarFiles = FileUtils.listFiles(
 			appServerLibPortalDir, new String[] {"jar"}, false);
 
@@ -525,7 +521,6 @@ public abstract class AbstractLiferayMojo extends AbstractMojo {
 	}
 
 	protected void initUtils() throws Exception {
-		getLog().info("initUtils for AbstractLiferayMojo - " + this.getClass().getName());
 		ClassLoader classLoader = getToolsClassLoader();
 
 		Class<?> clazz = classLoader.loadClass(

--- a/plugins/liferay-maven-plugin/src/main/java/com/liferay/maven/plugins/PluginDirectDeployerMojo.java
+++ b/plugins/liferay-maven-plugin/src/main/java/com/liferay/maven/plugins/PluginDirectDeployerMojo.java
@@ -15,6 +15,7 @@
 package com.liferay.maven.plugins;
 
 import com.liferay.maven.plugins.util.CopyTask;
+import com.liferay.maven.plugins.util.ExtractorUtil;
 import com.liferay.maven.plugins.util.FileUtil;
 
 import java.io.File;
@@ -202,6 +203,13 @@ public class PluginDirectDeployerMojo extends AbstractLiferayMojo {
 
 		CopyTask.copyFile(
 			extUtilFile, deployDependenciesDir, fileName, null, true, true);
+	}
+
+	@Override
+	protected void initUtils() throws Exception {
+		ExtractorUtil.getInstance().extractWeb(liferayVersion, "WEB-INF/classes/**/*.*", "WEB-INF/lib/**/*.*",
+				"WEB-INF/tld/**/*.*");
+		super.initUtils();
 	}
 
 	protected void deployExtWeb(File extWebDocrootDir) throws Exception {

--- a/plugins/liferay-maven-plugin/src/main/java/com/liferay/maven/plugins/ThemeMergeMojo.java
+++ b/plugins/liferay-maven-plugin/src/main/java/com/liferay/maven/plugins/ThemeMergeMojo.java
@@ -40,11 +40,6 @@ import org.dom4j.Element;
  */
 public class ThemeMergeMojo extends AbstractLiferayMojo {
 
-	@Override
-	protected void initUtils() throws Exception {
-
-	}
-
 	protected void cleanUpTemplates(File templatesDir) {
 		File initFile = new File(templatesDir, "init." + themeType);
 

--- a/plugins/liferay-maven-plugin/src/main/java/com/liferay/maven/plugins/ThemeMergeMojo.java
+++ b/plugins/liferay-maven-plugin/src/main/java/com/liferay/maven/plugins/ThemeMergeMojo.java
@@ -15,12 +15,7 @@
 package com.liferay.maven.plugins;
 
 import com.liferay.maven.plugins.theme.Theme;
-import com.liferay.maven.plugins.util.ContextReplace;
-import com.liferay.maven.plugins.util.GetterUtil;
-import com.liferay.maven.plugins.util.PortalUtil;
-import com.liferay.maven.plugins.util.SAXReaderUtil;
-import com.liferay.maven.plugins.util.StringUtil;
-import com.liferay.maven.plugins.util.Validator;
+import com.liferay.maven.plugins.util.*;
 
 import java.io.File;
 
@@ -44,6 +39,11 @@ import org.dom4j.Element;
  * @phase  process-sources
  */
 public class ThemeMergeMojo extends AbstractLiferayMojo {
+
+	@Override
+	protected void initUtils() throws Exception {
+
+	}
 
 	protected void cleanUpTemplates(File templatesDir) {
 		File initFile = new File(templatesDir, "init." + themeType);
@@ -107,6 +107,8 @@ public class ThemeMergeMojo extends AbstractLiferayMojo {
 			parentThemeArtifactId.equals("portal-web")) {
 
 			portalTheme = true;
+			ExtractorUtil.getInstance().extractWeb(liferayVersion, "html/css/**/*.*", "html/themes/_unstyled/**/*.*",
+					"html/themes/_styled/**/*.*", "html/themes/classic/**/*.*", "html/themes/control_panel/**/*.*");
 		}
 
 		if (!portalTheme) {
@@ -275,7 +277,6 @@ public class ThemeMergeMojo extends AbstractLiferayMojo {
 
 			FileUtils.copyDirectory(sourceCssDir, targetCssDir);
 
-			getLog().info("Copying " + sourceCssDir + " to " + targetCssDir);
 		}
 
 		File sourceImagesDir = new File(sourceDir, sourceTheme.getImagesPath());

--- a/plugins/liferay-maven-plugin/src/main/java/com/liferay/maven/plugins/util/ExtractorUtil.java
+++ b/plugins/liferay-maven-plugin/src/main/java/com/liferay/maven/plugins/util/ExtractorUtil.java
@@ -1,0 +1,120 @@
+package com.liferay.maven.plugins.util;
+
+import org.apache.maven.artifact.Artifact;
+import org.apache.maven.artifact.factory.ArtifactFactory;
+import org.apache.maven.artifact.repository.ArtifactRepository;
+import org.apache.maven.artifact.resolver.ArtifactResolver;
+import org.apache.maven.model.Dependency;
+import org.codehaus.plexus.archiver.UnArchiver;
+import org.codehaus.plexus.archiver.manager.ArchiverManager;
+import org.codehaus.plexus.components.io.fileselectors.FileSelector;
+import org.codehaus.plexus.components.io.fileselectors.IncludeExcludeFileSelector;
+
+import java.io.File;
+import java.util.ArrayList;
+import java.util.List;
+
+public class ExtractorUtil {
+
+	private static ExtractorUtil INSTANCE = null;
+
+	protected ArchiverManager archiverManager;
+	protected ArtifactFactory artifactFactory;
+	protected ArtifactResolver artifactResolver;
+	protected File appServerPortalDir;
+	protected ArtifactRepository localArtifactRepository;
+	protected List remoteArtifactRepositories;
+	private static final List<String> alreadyExtracted = new ArrayList<String>();
+
+	public ExtractorUtil(ArchiverManager archiverManager, ArtifactFactory artifactFactory, ArtifactResolver artifactResolver, File appServerPortalDir, ArtifactRepository localArtifactRepository, List remoteArtifactRepositories) {
+		this.archiverManager = archiverManager;
+		this.artifactFactory = artifactFactory;
+		this.artifactResolver = artifactResolver;
+		this.appServerPortalDir = appServerPortalDir;
+		this.localArtifactRepository = localArtifactRepository;
+		this.remoteArtifactRepositories = remoteArtifactRepositories;
+	}
+
+	public static void createInstance(ArtifactFactory artifactFactory, ArtifactResolver artifactResolver, ArtifactRepository localArtifactRepository, List remoteArtifactRepositories, File appServerPortalDir, ArchiverManager archiverManager) {
+		INSTANCE = new ExtractorUtil(archiverManager, artifactFactory, artifactResolver, appServerPortalDir, localArtifactRepository, remoteArtifactRepositories);
+	}
+
+	public static ExtractorUtil getInstance() {
+		return INSTANCE;
+	}
+
+	public void extractWeb(String liferayVersion, String... includes) throws Exception {
+		List<String> newIncludes = new ArrayList<String>();
+		for ( String include : includes ) {
+			if ( !alreadyExtracted.contains(include) )
+				newIncludes.add(include);
+			else
+				alreadyExtracted.add(include);
+		}
+		extract("com.liferay.portal", "portal-web", liferayVersion, "", "war", appServerPortalDir,
+				newIncludes.toArray(new String[]{}), null);
+	}
+
+	protected Dependency createDependency(
+			String groupId, String artifactId, String version, String classifier,
+			String type) {
+
+		Dependency dependency = new Dependency();
+
+		dependency.setArtifactId(artifactId);
+		dependency.setClassifier(classifier);
+		dependency.setGroupId(groupId);
+		dependency.setType(type);
+		dependency.setVersion(version);
+
+		return dependency;
+	}
+
+	protected Artifact resolveArtifact(Dependency dependency) throws Exception {
+		Artifact artifact = null;
+
+		if (Validator.isNull(dependency.getClassifier())) {
+			artifact = artifactFactory.createArtifact(
+					dependency.getGroupId(), dependency.getArtifactId(),
+					dependency.getVersion(), dependency.getScope(),
+					dependency.getType());
+		}
+		else {
+			artifact = artifactFactory.createArtifactWithClassifier(
+					dependency.getGroupId(), dependency.getArtifactId(),
+					dependency.getVersion(), dependency.getType(),
+					dependency.getClassifier());
+		}
+
+		artifactResolver.resolve(
+				artifact, remoteArtifactRepositories, localArtifactRepository);
+
+		return artifact;
+	}
+
+	public void extract(String groupId, String artifactId, String artifactVersion, String classifier,
+						String packageType, File workDir, String[] includes, String[] excludes) throws Exception {
+
+
+		Dependency dependency = createDependency(groupId, artifactId, artifactVersion, classifier, packageType);
+
+		Artifact artifact = resolveArtifact(dependency);
+
+		UnArchiver unArchiver = archiverManager.getUnArchiver(
+				artifact.getFile());
+
+		unArchiver.setDestDirectory(workDir);
+		unArchiver.setSourceFile(artifact.getFile());
+
+		IncludeExcludeFileSelector includeExcludeFileSelector =
+				new IncludeExcludeFileSelector();
+
+		includeExcludeFileSelector.setExcludes(excludes);
+		includeExcludeFileSelector.setIncludes(includes);
+
+		unArchiver.setFileSelectors(
+				new FileSelector[] {includeExcludeFileSelector});
+
+		unArchiver.extract();
+	}
+}

--- a/plugins/pom.xml
+++ b/plugins/pom.xml
@@ -4,7 +4,7 @@
 	<parent>
 		<groupId>com.liferay.maven</groupId>
 		<artifactId>maven-support</artifactId>
-		<version>6.2.10.11</version>
+		<version>6.2.10.12-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 	<modelVersion>4.0.0</modelVersion>

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 	<artifactId>maven-support</artifactId>
 	<packaging>pom</packaging>
 	<name>Liferay Maven 2 Support</name>
-	<version>6.2.10.11</version>
+	<version>6.2.10.12-SNAPSHOT</version>
 	<description>Parent project to support Maven 2 subprojects.</description>
 	<url>http://www.liferay.com</url>
 	<developers>


### PR DESCRIPTION
I branched the 6.2.10.11 tag of the liferay maven plugins to optimize the extraction of the portal-web.  This decreases the build time when the parameter appServerPortalDir is not set.  The changes optimize the build time by not extracting the portal-web contents repeatedly.  The classPath building done in AbstractLiferayMojo's methods getToolsClassPath() and getProjectClassPath() is also not repeatedly done, as this can be a costly operation.