### PR TITLE
Maven 206 - enable correct jdk version guessing in liferay children builds

### DIFF
--- a/archetypes/liferay-ext-archetype/pom.xml
+++ b/archetypes/liferay-ext-archetype/pom.xml
@@ -4,7 +4,7 @@
 	<parent>
 		<groupId>com.liferay.maven</groupId>
 		<artifactId>liferay-archetypes</artifactId>
-		<version>6.2.5</version>
+		<version>6.2.5.1-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 	<modelVersion>4.0.0</modelVersion>

--- a/archetypes/liferay-hook-archetype/pom.xml
+++ b/archetypes/liferay-hook-archetype/pom.xml
@@ -4,7 +4,7 @@
 	<parent>
 		<groupId>com.liferay.maven</groupId>
 		<artifactId>liferay-archetypes</artifactId>
-		<version>6.2.5</version>
+		<version>6.2.5.1-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 	<modelVersion>4.0.0</modelVersion>

--- a/archetypes/liferay-layouttpl-archetype/pom.xml
+++ b/archetypes/liferay-layouttpl-archetype/pom.xml
@@ -4,7 +4,7 @@
 	<parent>
 		<groupId>com.liferay.maven</groupId>
 		<artifactId>liferay-archetypes</artifactId>
-		<version>6.2.5</version>
+		<version>6.2.5.1-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 	<modelVersion>4.0.0</modelVersion>

--- a/archetypes/liferay-portlet-archetype/pom.xml
+++ b/archetypes/liferay-portlet-archetype/pom.xml
@@ -4,7 +4,7 @@
 	<parent>
 		<groupId>com.liferay.maven</groupId>
 		<artifactId>liferay-archetypes</artifactId>
-		<version>6.2.5</version>
+		<version>6.2.5.1-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 	<modelVersion>4.0.0</modelVersion>

--- a/archetypes/liferay-portlet-icefaces-archetype/pom.xml
+++ b/archetypes/liferay-portlet-icefaces-archetype/pom.xml
@@ -4,7 +4,7 @@
 	<parent>
 		<groupId>com.liferay.maven</groupId>
 		<artifactId>liferay-archetypes</artifactId>
-		<version>6.2.5</version>
+		<version>6.2.5.1-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 	<modelVersion>4.0.0</modelVersion>

--- a/archetypes/liferay-portlet-jsf-archetype/pom.xml
+++ b/archetypes/liferay-portlet-jsf-archetype/pom.xml
@@ -4,7 +4,7 @@
 	<parent>
 		<groupId>com.liferay.maven</groupId>
 		<artifactId>liferay-archetypes</artifactId>
-		<version>6.2.5</version>
+		<version>6.2.5.1-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 	<modelVersion>4.0.0</modelVersion>

--- a/archetypes/liferay-portlet-liferay-faces-alloy-archetype/pom.xml
+++ b/archetypes/liferay-portlet-liferay-faces-alloy-archetype/pom.xml
@@ -4,7 +4,7 @@
 	<parent>
 		<groupId>com.liferay.maven</groupId>
 		<artifactId>liferay-archetypes</artifactId>
-		<version>6.2.5</version>
+		<version>6.2.5.1-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 	<modelVersion>4.0.0</modelVersion>

--- a/archetypes/liferay-portlet-primefaces-archetype/pom.xml
+++ b/archetypes/liferay-portlet-primefaces-archetype/pom.xml
@@ -4,7 +4,7 @@
 	<parent>
 		<groupId>com.liferay.maven</groupId>
 		<artifactId>liferay-archetypes</artifactId>
-		<version>6.2.5</version>
+		<version>6.2.5.1-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 	<modelVersion>4.0.0</modelVersion>

--- a/archetypes/liferay-portlet-richfaces-archetype/pom.xml
+++ b/archetypes/liferay-portlet-richfaces-archetype/pom.xml
@@ -4,7 +4,7 @@
 	<parent>
 		<groupId>com.liferay.maven</groupId>
 		<artifactId>liferay-archetypes</artifactId>
-		<version>6.2.5</version>
+		<version>6.2.5.1-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 	<modelVersion>4.0.0</modelVersion>

--- a/archetypes/liferay-portlet-spring-mvc-archetype/pom.xml
+++ b/archetypes/liferay-portlet-spring-mvc-archetype/pom.xml
@@ -4,7 +4,7 @@
 	<parent>
 		<groupId>com.liferay.maven</groupId>
 		<artifactId>liferay-archetypes</artifactId>
-		<version>6.2.5</version>
+		<version>6.2.5.1-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 	<modelVersion>4.0.0</modelVersion>

--- a/archetypes/liferay-servicebuilder-archetype/pom.xml
+++ b/archetypes/liferay-servicebuilder-archetype/pom.xml
@@ -4,7 +4,7 @@
 	<parent>
 		<groupId>com.liferay.maven</groupId>
 		<artifactId>liferay-archetypes</artifactId>
-		<version>6.2.5</version>
+		<version>6.2.5.1-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 	<modelVersion>4.0.0</modelVersion>

--- a/archetypes/liferay-theme-archetype/pom.xml
+++ b/archetypes/liferay-theme-archetype/pom.xml
@@ -4,7 +4,7 @@
 	<parent>
 		<groupId>com.liferay.maven</groupId>
 		<artifactId>liferay-archetypes</artifactId>
-		<version>6.2.5</version>
+		<version>6.2.5.1-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 	<modelVersion>4.0.0</modelVersion>

--- a/archetypes/liferay-web-archetype/pom.xml
+++ b/archetypes/liferay-web-archetype/pom.xml
@@ -4,7 +4,7 @@
 	<parent>
 		<groupId>com.liferay.maven</groupId>
 		<artifactId>liferay-archetypes</artifactId>
-		<version>6.2.5</version>
+		<version>6.2.5.1-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 	<modelVersion>4.0.0</modelVersion>

--- a/archetypes/pom.xml
+++ b/archetypes/pom.xml
@@ -4,7 +4,7 @@
 	<parent>
 		<groupId>com.liferay.maven</groupId>
 		<artifactId>maven-support</artifactId>
-		<version>6.2.5</version>
+		<version>6.2.5.1-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 	<modelVersion>4.0.0</modelVersion>

--- a/plugins/liferay-maven-plugin/pom.xml
+++ b/plugins/liferay-maven-plugin/pom.xml
@@ -4,13 +4,13 @@
 	<parent>
 		<artifactId>plugins</artifactId>
 		<groupId>com.liferay.maven</groupId>
-		<version>6.2.5</version>
+		<version>6.2.5.1-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 	<modelVersion>4.0.0</modelVersion>
 	<groupId>com.liferay.maven.plugins</groupId>
 	<artifactId>liferay-maven-plugin</artifactId>
-	<version>6.2.5</version>
+	<version>6.2.5.1-SNAPSHOT</version>
 	<packaging>maven-plugin</packaging>
 	<name>Liferay Maven Plugin</name>
 	<description>Contains goals to manage Liferay plugins.</description>

--- a/plugins/liferay-maven-plugin/src/main/java/com/liferay/maven/plugins/AbstractToolsLiferayMojo.java
+++ b/plugins/liferay-maven-plugin/src/main/java/com/liferay/maven/plugins/AbstractToolsLiferayMojo.java
@@ -619,7 +619,11 @@ public abstract class AbstractToolsLiferayMojo extends AbstractLiferayMojo {
 
 		projectBuildingRequest.setActiveProfileIds(activeProfileIds);
 		projectBuildingRequest.setProfiles(
-			mavenExecutionRequest.getProfiles());
+				mavenExecutionRequest.getProfiles());
+		projectBuildingRequest.getSystemProperties()
+				.putAll(mavenExecutionRequest.getSystemProperties());
+		projectBuildingRequest.getUserProperties()
+				.putAll(mavenExecutionRequest.getUserProperties());
 
 		ProjectBuildingResult projectBuildingResult = projectBuilder.build(
 			pomArtifact, true, projectBuildingRequest);

--- a/plugins/pom.xml
+++ b/plugins/pom.xml
@@ -4,7 +4,7 @@
 	<parent>
 		<groupId>com.liferay.maven</groupId>
 		<artifactId>maven-support</artifactId>
-		<version>6.2.5</version>
+		<version>6.2.5.1-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 	<modelVersion>4.0.0</modelVersion>

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 	<artifactId>maven-support</artifactId>
 	<packaging>pom</packaging>
 	<name>Liferay Maven Support</name>
-	<version>6.2.5</version>
+	<version>6.2.5.1-SNAPSHOT</version>
 	<description>Parent project to support Maven subprojects.</description>
 	<url>http://www.liferay.com</url>
 	<developers>


### PR DESCRIPTION
As stated in https://issues.liferay.com/browse/MAVEN-206, current build-css target can fail if plugin dependencies imply profile activation by jdk version. In the original bug report, failure is triggered by a apache commons dependency.
Other failure can be triggerred by cxf code generation.

This fix, apart the version change, modify AbstractToolsLiferayMojo.java to cascade system and user properties.