### PR TITLE
Fixed: whitelisting multiple sass directories for build-css goal not possible in version 6.2.10.16

### DIFF
--- a/plugins/liferay-maven-plugin/src/main/java/com/liferay/maven/plugins/SassToCssBuilderMojo.java
+++ b/plugins/liferay-maven-plugin/src/main/java/com/liferay/maven/plugins/SassToCssBuilderMojo.java
@@ -63,7 +63,7 @@ public class SassToCssBuilderMojo extends AbstractToolsLiferayMojo {
 			}
 
 			for (int i = 0; i < dirNames.length; i++) {
-                args[i] = "sass.dir." + i + "=" + dirNames[i];
+				args[i] = "sass.dir." + i + "=" + dirNames[i];
 			}
 		}
 		else {

--- a/plugins/liferay-maven-plugin/src/main/java/com/liferay/maven/plugins/SassToCssBuilderMojo.java
+++ b/plugins/liferay-maven-plugin/src/main/java/com/liferay/maven/plugins/SassToCssBuilderMojo.java
@@ -63,9 +63,7 @@ public class SassToCssBuilderMojo extends AbstractToolsLiferayMojo {
 			}
 
 			for (int i = 0; i < dirNames.length; i++) {
-				if (getPortalMajorVersion() < PORTAL_VERSION_6_2) {
-					args[i] = "sass.dir." + i + "=" + dirNames[i];
-				}
+                args[i] = "sass.dir." + i + "=" + dirNames[i];
 			}
 		}
 		else {


### PR DESCRIPTION
Theme plugin build ends with null pointer exception if following configuration is used with liferay 6.2:
```            <plugin>
                <groupId>com.liferay.maven.plugins</groupId>
                <artifactId>liferay-maven-plugin</artifactId>
                <version>6.2.10.16</version>
                <executions>
                    <execution>
                        <phase>generate-sources</phase>
                        <goals>
                            <goal>theme-merge</goal>
                            <goal>build-css</goal>
                            <goal>build-thumbnail</goal>
                        </goals>
                    </execution>
                </executions>
                <configuration>
                    <sassDirNames>/theme1/css,/theme2/css,/theme3/css</sassDirNames>
                    (...)
                </configuration>
            </plugin>
```

[Problematic line](https://github.com/liferay/liferay-maven-support/blob/master/plugins/liferay-maven-plugin/src/main/java/com/liferay/maven/plugins/SassToCssBuilderMojo.java#L65)

Solution, removed condition that sassDirNames are processed only for liferay version lower than 6.2.  [Liferay 6.2 is prepared for multiple values in the sassDirNames list](https://github.com/liferay/liferay-portal/blob/6.2.x/portal-impl/src/com/liferay/portal/tools/SassToCssBuilder.java#L111)